### PR TITLE
Add binary tree visualization

### DIFF
--- a/test.rkt
+++ b/test.rkt
@@ -1,0 +1,58 @@
+;; The first three lines of this file were inserted by DrRacket. They record metadata
+;; about the language level of this file in a form that our tools can easily process.
+#reader(lib "htdp-beginner-abbr-reader.ss" "lang")((modname test) (read-case-sensitive #t) (teachpacks ()) (htdp-settings #(#t write repeating-decimal #f #t none #f () #f)))
+(require "tree-visualizer.rkt")
+
+
+(define-struct node (key left right))
+(define-struct alt-node (left right key))
+
+
+(define n (make-node 5
+                     (make-node 3
+                                (make-node 1 empty empty)
+                                (make-node 4 empty empty))
+                     (make-node 8
+                                (make-node 7
+                                           (make-node 6 empty empty)
+                                           empty)
+                                (make-node 10
+                                           (make-node 9 empty empty)
+                                           (make-node 11
+                                                      empty
+                                                      (make-node 15
+                                                                 (make-node 13
+                                                                            (make-node 12 empty empty)
+                                                                            empty)
+                                                                 (make-node 16 empty empty)))))))
+
+(define n-alt (make-alt-node
+               (make-alt-node
+                (make-alt-node empty empty 1)
+                (make-alt-node empty empty 4)
+                3)
+               (make-alt-node
+                (make-alt-node
+                 (make-alt-node empty empty 6)
+                 empty
+                 7)
+                (make-alt-node
+                 (make-alt-node empty empty 9)
+                 (make-alt-node
+                  empty
+                  (make-alt-node
+                   (make-alt-node
+                    (make-alt-node empty empty 12)
+                    empty
+                    13)
+                   (make-alt-node empty empty 16)
+                   15)
+                  11)
+                 10)
+                8)
+               5))
+
+
+(visualize-binary-tree n)
+(visualize-binary-tree empty)
+(visualize-binary-tree n-alt '(left right key))

--- a/tree-visualizer.rkt
+++ b/tree-visualizer.rkt
@@ -1,10 +1,45 @@
 #lang racket
+
 (require pict/tree-layout)
 (require pict)
 (define-struct unde-tree (left right))
 (define-struct de-tree (left right val))
 
-(provide unde-tree de-tree visualize-decorated-tree visualize-undecorated-tree)
+(provide visualize-binary-tree
+         unde-tree de-tree
+         visualize-decorated-tree
+         visualize-undecorated-tree)
+
+
+;; (bt->tree-layout tree order) produces a tree-layout from tree;
+;;   this is only used as a helper of visualize-binary-tree
+;; bt->tree-layout: BinaryTree (listof Sym) -> Tree-Layout
+(define (bt->tree-layout tree order)
+  (if (empty? tree)
+      (tree-layout #:pict (blank) #f #f)
+      (local
+        [(define h (make-hash (map cons order (build-list 3 add1))))
+         (define v (struct->vector tree))
+         (define key (vector-ref v (hash-ref h 'key)))
+         (define left (vector-ref v (hash-ref h 'left)))
+         (define right (vector-ref v (hash-ref h 'right)))]
+        (tree-layout #:pict (text (number->string key))
+                     (if (empty? left)
+                         #f
+                         (bt->tree-layout left order))
+                     (if (empty? right)
+                         #f
+                         (bt->tree-layout right order))))))
+
+
+;; (visualize-binary-tree tree [form]) produces a visualization of tree
+;;   with nodes defined as struct in the form (key left right);
+;;   an optional argument [form] can be supplied to specify the form of
+;;   node struct
+;; visualize-binary-tree: BinaryTree [(listof Sym)] -> Void
+(define (visualize-binary-tree tree [form '(key left right)])
+  (println (naive-layered (bt->tree-layout tree form))))
+
 
 (define (visualize-undecorated-tree t)
   (if (empty? t)


### PR DESCRIPTION
Support visualization for any binary tree with nodes defined as struct of 3 properties (key left right).
Read `test.rkt` for examples.